### PR TITLE
Avoid namespace pollution by not exporting short-form notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ with [Unicode support](https://docs.julialang.org/en/v1/manual/unicode-input/ind
 - Leverages [MortalityTables.jl](https://github.com/JuliaActuary/MortalityTables.jl) for
 the mortality calculations
 - Contains common insurance calculations such as:
-    - `A(life)`: Whole life
-    - `A(life,n)`: Term life for `n` years
+    - `insurance(life)`: Whole life
+    - `insurance(life,n)`: Term life for `n` years
     - `ä(life)`: Life contingent annuity due
     - `ä(life,n)`: Life contingent annuity due for `n` years
 - Contains various commutation functions such as `D(x)`,`M(x)`,`C(x)`, etc.
@@ -52,9 +52,9 @@ lc = LifeContingency(
 )
 
 
-A(lc)        # Whole Life insurance
-A(lc,10)     # 10 year term insurance
-P(lc)        # Net whole life premium 
+insurance(lc)        # Whole Life insurance
+insurance(lc,10)     # 10 year term insurance
+premium_net(lc)        # Net whole life premium 
 V(lc,5)      # Net premium reserve for whole life insurance at time 5
 ä(lc)        # Whole life annuity due
 ä(lc, 5)     # 5 year annuity due
@@ -93,7 +93,7 @@ lc = LifeContingency(
 )
 
 term = 10
-A(lc,term) # around 0.055
+insurance(lc,term) # around 0.055
 ```
 #### Extending example to use autocorrelated interest rates
 You can use autocorrelated interest rates - substitute the following in the prior example
@@ -138,7 +138,7 @@ whole_life_costs = map(tables) do t
                 int
             )
 
-        P(lc)
+        premium_net(lc)
 
     end
 end
@@ -164,10 +164,56 @@ l2 = SingleLife(mort = m2.ultimate, issue_age = 37)
 jl = JointLife(lives=(l1, l2), contingency=LastSurvivor(), joint_assumption=Frasier())
 
 
-A(jl)   # whole life insurance
+insurance(jl)   # whole life insurance
 ...     # similar functions as shown in the first example above
 ```
+## Commutation and Unexported Function shorthand
 
+Because it's so common to use certain variables in your own code, LifeContingencies avoids exporting certain variables/functions so that it doesn't collide with your own usage. For example, you may find yourself doing something like:
+
+```julia
+a = ...
+b = ...
+resutl = b - a
+```
+
+If you imported `using LifeContingencies` and the package exported `a` (`annuity_immediate`) then you could have problems if you tried to do the above. To avoid this, we only export long-form functions like `annuity_immediate`. To utilize the shorthand, you can include them into your code's scope like so:
+https://docs.julialang.org/en/latest/manual/modules/#Summary-of-module-usage-1
+
+```julia
+using LifeContingencies # brings all the default functions into your scope
+using LifeContingencies: a, ä # also brings the short-form annuity functions into scope
+```
+
+**Or** you can do the following:
+
+```julia
+using LifeContingencies # brings all the default functions into your scope
+... # later on in the code
+LifeContingencies.ä(...) # utilize the unexported function with the module name
+```
+
+
+### Actuarial notation shorthand
+
+```julia
+V => reserve_premium_net
+v => disc
+A => insurance
+ä => annuity_due
+a => annuity_immediate
+P => premium_net
+ω => omega
+```
+### Commutation functions
+
+```julia
+l,
+D,
+M,
+N,
+C,
+```
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ resutl = b - a
 ```
 
 If you imported `using LifeContingencies` and the package exported `a` (`annuity_immediate`) then you could have problems if you tried to do the above. To avoid this, we only export long-form functions like `annuity_immediate`. To utilize the shorthand, you can include them into your code's scope like so:
-https://docs.julialang.org/en/latest/manual/modules/#Summary-of-module-usage-1
 
 ```julia
 using LifeContingencies # brings all the default functions into your scope
@@ -192,7 +191,7 @@ using LifeContingencies # brings all the default functions into your scope
 ... # later on in the code
 LifeContingencies.ä(...) # utilize the unexported function with the module name
 ```
-
+For more on module scoping, see the [Julia Manual section](https://docs.julialang.org/en/latest/manual/modules/#Summary-of-module-usage-1).
 
 ### Actuarial notation shorthand
 

--- a/src/LifeContingencies.jl
+++ b/src/LifeContingencies.jl
@@ -392,7 +392,7 @@ Life annuity immediate for the life contingency `lc` with the benefit period sta
 
 """
 # eq 5.11 ALMCR 2nd ed
-a(lc::LifeContingency;start_time=0) = annuity_due(lc,start_time=start_time) - 1 
+annuity_immediate(lc::LifeContingency;start_time=0) = annuity_due(lc,start_time=start_time) - 1 
 
 # eq 5.13 ALMCR 2nd ed
 function annuity_immediate(lc::LifeContingency,npayments; start_time=0) 

--- a/test/joint_life.jl
+++ b/test/joint_life.jl
@@ -31,9 +31,9 @@
             ins_l1 = LifeContingency(jl.lives[1],InterestRate(0.05))
             ins_l2 = LifeContingency(jl.lives[2],InterestRate(0.05))
             # problem 9.1.f
-            @test isapprox( ä(ins,5), 4.5437, atol = 1e-4)
+            @test isapprox( annuity_due(ins,5), 4.5437, atol = 1e-4)
 
-            @test isapprox( ä(ins), 4.5437, atol = 1e-4)
+            @test isapprox( annuity_due(ins), 4.5437, atol = 1e-4)
         end
     
         @testset "CIA tables" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using LifeContingencies
+using LifeContingencies: l,D,M,N,C
 using Test
 import Distributions: Normal
 using MortalityTables

--- a/test/simple_mort.jl
+++ b/test/simple_mort.jl
@@ -8,15 +8,15 @@
     )
 
     @test omega(ins) ≈ 1
-    @test ä(ins) ≈ 1 + 1 * .5 / 1.05
-    @test ä(ins,1) ≈ 1
-    @test ä(ins,0) == 0
-    @test a(ins,1) ≈ 1 * .5 / 1.05
-    @test a(ins,0) == 0
+    @test annuity_due(ins) ≈ 1 + 1 * .5 / 1.05
+    @test annuity_due(ins,1) ≈ 1
+    @test annuity_due(ins,0) == 0
+    @test annuity_immediate(ins,1) ≈ 1 * .5 / 1.05
+    @test annuity_immediate(ins,0) == 0
 
-    @test A(ins) ≈ 0.5 / 1.05
-    @test A(ins,1) ≈ 0.5 / 1.05
-    @test A(ins,0) ≈ 0
+    @test insurance(ins) ≈ 0.5 / 1.05
+    @test insurance(ins,1) ≈ 0.5 / 1.05
+    @test insurance(ins,0) ≈ 0
 
 
     ins_jl = LifeContingency(
@@ -25,16 +25,16 @@
     )
 
     @test omega(ins_jl) ≈ 1
-    @test ä(ins_jl) ≈ 1 + 1 * .75 / 1.05
-    @test ä(ins_jl,1) ≈ 1
-    @test a(ins_jl,1) ≈ 1 * .75 / 1.05
-    @test ä(ins_jl,2) ≈ 1 + 1 * .75 / 1.05
-    @test ä(ins_jl,0) == 0
+    @test annuity_due(ins_jl) ≈ 1 + 1 * .75 / 1.05
+    @test annuity_due(ins_jl,1) ≈ 1
+    @test annuity_immediate(ins_jl,1) ≈ 1 * .75 / 1.05
+    @test annuity_due(ins_jl,2) ≈ 1 + 1 * .75 / 1.05
+    @test annuity_due(ins_jl,0) == 0
 
     @test survivorship(ins_jl,1) ≈ .5 + .5 - .5 * .5
-    @test A(ins_jl) ≈ .25 / 1.05
-    @test A(ins_jl,1) ≈ 0.25 / 1.05
-    @test A(ins_jl,0) ≈ 0
+    @test insurance(ins_jl) ≈ .25 / 1.05
+    @test insurance(ins_jl,1) ≈ 0.25 / 1.05
+    @test insurance(ins_jl,0) ≈ 0
 end
 
 @testset "two year no discount" begin
@@ -47,23 +47,23 @@ end
     )
 
     @test omega(ins) ≈ 2
-    @test ä(ins) ≈ 3
-    @test ä(ins;start_time=1) ≈ 2
-    @test ä(ins,1) ≈ 1 
-    @test ä(ins,2) ≈ 2
-    @test ä(ins,2;start_time=2) ≈ 0
-    @test ä(ins,3) ≈ 3
-    @test ä(ins,0) == 0
-    @test a(ins,0) == 0
-    @test a(ins,1) ≈ 1
-    @test a(ins,1;start_time=1) ≈ 0
-    @test a(ins;start_time=2) ≈ 0
-    @test a(ins,2) ≈ 2
-    @test a(ins) ≈ 2
+    @test annuity_due(ins) ≈ 3
+    @test annuity_due(ins;start_time=1) ≈ 2
+    @test annuity_due(ins,1) ≈ 1 
+    @test annuity_due(ins,2) ≈ 2
+    @test annuity_due(ins,2;start_time=2) ≈ 0
+    @test annuity_due(ins,3) ≈ 3
+    @test annuity_due(ins,0) == 0
+    @test annuity_immediate(ins,0) == 0
+    @test annuity_immediate(ins,1) ≈ 1
+    @test annuity_immediate(ins,1;start_time=1) ≈ 0
+    @test annuity_immediate(ins;start_time=2) ≈ 0
+    @test annuity_immediate(ins,2) ≈ 2
+    @test annuity_immediate(ins) ≈ 2
 
-    @test A(ins) ≈ 0
-    @test A(ins,1) ≈ 0
-    @test A(ins,0) ≈ 0
+    @test insurance(ins) ≈ 0
+    @test insurance(ins,1) ≈ 0
+    @test insurance(ins,0) ≈ 0
 
     ins_jl = LifeContingency(
         JointLife(
@@ -89,17 +89,17 @@ end
     )
 
     @test omega(ins) ≈ 2
-    @test ä(ins) ≈ 1 + 1 * .5 * 1 / 1.05 +  1 * .25 / 1.05 ^2
-    @test ä(ins,1) ≈ 1 
-    @test ä(ins,2) ≈ 1 + 1 * .5 * 1 / 1.05
-    @test ä(ins,3) ≈ 1 + 1 * .5 * 1 / 1.05 +  1 * .25 / 1.05 ^2
-    @test ä(ins,0) ≈ 0
-    @test a(ins,0) ≈ 0
-    @test a(ins,1) ≈ 1 * .5 * 1 / 1.05
+    @test annuity_due(ins) ≈ 1 + 1 * .5 * 1 / 1.05 +  1 * .25 / 1.05 ^2
+    @test annuity_due(ins,1) ≈ 1 
+    @test annuity_due(ins,2) ≈ 1 + 1 * .5 * 1 / 1.05
+    @test annuity_due(ins,3) ≈ 1 + 1 * .5 * 1 / 1.05 +  1 * .25 / 1.05 ^2
+    @test annuity_due(ins,0) ≈ 0
+    @test annuity_immediate(ins,0) ≈ 0
+    @test annuity_immediate(ins,1) ≈ 1 * .5 * 1 / 1.05
 
-    @test A(ins) ≈ 0.5 / 1.05 + 0.5 * 0.5 / 1.05 ^ 2
-    @test A(ins,1) ≈ 0.5 / 1.05
-    @test A(ins,0) ≈ 0
+    @test insurance(ins) ≈ 0.5 / 1.05 + 0.5 * 0.5 / 1.05 ^ 2
+    @test insurance(ins,1) ≈ 0.5 / 1.05
+    @test insurance(ins,0) ≈ 0
 
     ins_jl = LifeContingency(
         JointLife(
@@ -125,16 +125,16 @@ end
     )
 
     @test omega(ins) ≈ 2
-    @test ä(ins,1) ≈ 1
-    @test ä(ins,2) ≈ 1 + 1 * .5 * 1 / 1.05 
-    @test ä(ins,3) ≈ 1 + 1 * .5 * 1 / 1.05 + 1 * .25 * 1 / 1.05 ^ 2
-    @test ä(ins,0) == 0
-    @test a(ins,0) == 0
-    @test a(ins,1) ≈ 1 * .5 * 1 / 1.05 
+    @test annuity_due(ins,1) ≈ 1
+    @test annuity_due(ins,2) ≈ 1 + 1 * .5 * 1 / 1.05 
+    @test annuity_due(ins,3) ≈ 1 + 1 * .5 * 1 / 1.05 + 1 * .25 * 1 / 1.05 ^ 2
+    @test annuity_due(ins,0) == 0
+    @test annuity_immediate(ins,0) == 0
+    @test annuity_immediate(ins,1) ≈ 1 * .5 * 1 / 1.05 
 
-    @test A(ins) ≈ 0.5 / 1.05 + 0.5 * 0.5 / 1.05 ^ 2
-    @test A(ins,1) ≈ 0.5 / 1.05
-    @test A(ins,0) ≈ 0
+    @test insurance(ins) ≈ 0.5 / 1.05 + 0.5 * 0.5 / 1.05 ^ 2
+    @test insurance(ins,1) ≈ 0.5 / 1.05
+    @test insurance(ins,0) ≈ 0
 
     ins_jl = LifeContingency(
         JointLife(
@@ -145,12 +145,12 @@ end
     )
 
     @test omega(ins_jl) ≈ 2
-    @test ä(ins_jl,1) ≈ 1
-    @test ä(ins_jl,2) ≈ 1 + 1 * .75 /1.05
-    @test ä(ins_jl,3) ≈ 1 + 1 * .75 /1.05 + 1 * survivorship(ins_jl,2) / 1.05 ^ 2
-    @test ä(ins_jl,0) == 0
-    @test a(ins_jl,0) == 0
-    @test a(ins_jl,1) ≈ 1 * .75 /1.05
+    @test annuity_due(ins_jl,1) ≈ 1
+    @test annuity_due(ins_jl,2) ≈ 1 + 1 * .75 /1.05
+    @test annuity_due(ins_jl,3) ≈ 1 + 1 * .75 /1.05 + 1 * survivorship(ins_jl,2) / 1.05 ^ 2
+    @test annuity_due(ins_jl,0) == 0
+    @test annuity_immediate(ins_jl,0) == 0
+    @test annuity_immediate(ins_jl,1) ≈ 1 * .75 /1.05
 
 end
 
@@ -182,20 +182,20 @@ t = UltimateMortality(maleMort)
     @test M(ins, 1) ≈ 0.0355801393752753
     @test M(ins, 2) ≈ 0.0351775312392208
 
-    @test A(ins   ) ≈ 0.04223728223
-    @test A(ins, 0) ≈ 0.0
-    @test A(ins, 1) ≈ 0.0066571428571429
-    @test ä(ins, 0) ≈ 0.0
-    @test ä(ins, 1) ≈ 1.0 
-    @test ä(ins, 2) ≈ 1.0 + survivorship(ins,1) / 1.05
-    @test a(ins, 0) ≈ 0.0
-    @test a(ins, 1) ≈ survivorship(ins,1) / 1.05
+    @test insurance(ins   ) ≈ 0.04223728223
+    @test insurance(ins, 0) ≈ 0.0
+    @test insurance(ins, 1) ≈ 0.0066571428571429
+    @test annuity_due(ins, 0) ≈ 0.0
+    @test annuity_due(ins, 1) ≈ 1.0 
+    @test annuity_due(ins, 2) ≈ 1.0 + survivorship(ins,1) / 1.05
+    @test annuity_immediate(ins, 0) ≈ 0.0
+    @test annuity_immediate(ins, 1) ≈ survivorship(ins,1) / 1.05
 
-    @test A(ins, 30) ≈ 0.0137761089686975
+    @test insurance(ins, 30) ≈ 0.0137761089686975
 
     @test N(ins, 26) ≈ 5.156762988852310
     @test D(ins, 26) ≈ 0.275358702015970
-    @test ä(ins, 26) ≈ 14.9562540842669
+    @test annuity_due(ins, 26) ≈ 14.9562540842669
 
 
 

--- a/test/single_life.jl
+++ b/test/single_life.jl
@@ -25,12 +25,12 @@
         @test M(ins, 1) ≈ 0.1800468954723570
         @test M(ins, 2) ≈ 0.0264364171050101
 
-        @test A(ins) ≈ 0.9418373716628330
-        @test ä(ins) ≈ 1.2214151950805000
+        @test insurance(ins) ≈ 0.9418373716628330
+        @test annuity_due(ins) ≈ 1.2214151950805000
 
         qs = t.ultimate[116:118]
-        @test A(ins, 3) ≈ sum(qs .* [1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 1:3])
-        @test ä(ins, 3) ≈ sum([1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 0:2])
+        @test insurance(ins, 3) ≈ sum(qs .* [1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 1:3])
+        @test annuity_due(ins, 3) ≈ sum([1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 0:2])
 
     end
 
@@ -62,17 +62,17 @@
         @test M(ins, 1) ≈ 0.1104702077177110
         @test M(ins, 2) ≈ 0.1100531118446950
 
-        @test A(ins) ≈ 0.1107844934319970
-        @test ä(ins) ≈ 18.6735256379281000
-        @test P(ins) ≈ 0.0059327036350854
-        @test V(ins, 1) ≈ 0.0059012862412992
-        @test V(ins, 2) ≈ 0.0119711961204193
+        @test insurance(ins) ≈ 0.1107844934319970
+        @test annuity_due(ins) ≈ 18.6735256379281000
+        @test premium_net(ins) ≈ 0.0059327036350854
+        @test  reserve_premium_net(ins, 1) ≈ 0.0059012862412992
+        @test  reserve_premium_net(ins, 2) ≈ 0.0119711961204193
 
         qs = t.select[30][30:55]
-        @test A(ins, 26) ≈ sum(qs .* [1;cumprod(1 .- qs[1:25])] .* [1.05 ^ -t for t in 1:26])
-        @test ä(ins, 26) ≈ sum([1;cumprod(1 .- qs[1:25])] .* [1.05 ^ -t for t in 0:25])
+        @test insurance(ins, 26) ≈ sum(qs .* [1;cumprod(1 .- qs[1:25])] .* [1.05 ^ -t for t in 1:26])
+        @test annuity_due(ins, 26) ≈ sum([1;cumprod(1 .- qs[1:25])] .* [1.05 ^ -t for t in 0:25])
 
-        @test P(ins, 26) ≈ A(ins, 26) /  ä(ins, 26) 
+        @test premium_net(ins, 26) ≈ insurance(ins, 26) /  annuity_due(ins, 26) 
 
     end
 end

--- a/test/single_life.jl
+++ b/test/single_life.jl
@@ -27,11 +27,18 @@
 
         @test insurance(ins) ≈ 0.9418373716628330
         @test annuity_due(ins) ≈ 1.2214151950805000
-
+        
         qs = t.ultimate[116:118]
         @test insurance(ins, 3) ≈ sum(qs .* [1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 1:3])
         @test annuity_due(ins, 3) ≈ sum([1;cumprod(1 .- qs[1:2])] .* [1.05 ^ -t for t in 0:2])
-
+        
+        @test LifeContingencies.V(ins,1) == reserve_premium_net(ins,1)
+        @test LifeContingencies.v(ins,1) == disc(ins,1)
+        @test LifeContingencies.A(ins) == insurance(ins)
+        @test LifeContingencies.ä(ins) == annuity_due(ins)
+        @test LifeContingencies.a(ins) == annuity_immediate(ins)
+        @test LifeContingencies.P(ins) == premium_net(ins)
+        @test LifeContingencies.ω(ins) == omega(ins)
     end
 
     @testset "issue age 30" begin


### PR DESCRIPTION
closes #13 