### PR TITLE
Trigger CI on tag pushes so deploydocs publishes versioned docs

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags: ['*']
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
## Summary

The CI workflow only triggers on master pushes and PRs, never on tag pushes. When TagBot creates a release tag, no CI run fires against the tag, so \`deploydocs\` never publishes the versioned \`/vX.Y.Z/\` directory and the \`stable\` symlink never advances.

This isn't actively biting today because no new tag has been cut since 2023 (current \`/stable/\` is at v2.5.0, matching the latest release), but the next tag would silently fail to update the docs site — same bug that has left FinanceModels at v4.17.1 and ActuaryUtilities at v5.2.1. Preemptive fix.

Adding \`tags: ['*']\` matches the standard Documenter recommendation and the existing config in \`FinanceCore.jl\`, \`EconomicScenarioGenerators.jl\`, and \`TermLife.jl\`.

## Test plan

- [ ] PR CI passes (same as today's master CI behavior)
- [ ] Next time a tag is cut, confirm the new versioned dir is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)